### PR TITLE
Fix page geticsfeed and add support for event times

### DIFF
--- a/Upload/framework/lib/data/stundenplandata.class.php
+++ b/Upload/framework/lib/data/stundenplandata.class.php
@@ -509,14 +509,18 @@ class stundenplandata {
      */
     public static function getTimesForWeekdayAndPeriod($day_of_week, $period) {
         $settings = DB::getSettings();
+        if ($settings->getValue("stundenplan-everydayothertimes") <= 0) {
+            // If the timetable uses the same times every day, just query the times for Monday.
+            $day_of_week = 1;
+        }
         $start = $settings->getValue("stundenplan-stunde-$day_of_week-$period-start");
         $end = $settings->getValue("stundenplan-stunde-$day_of_week-$period-ende");
         if ($start === null || $end === null) { return null; }
 
         $today = new DateTimeImmutable("today");  # This is the current date time at 00:00h.
         return array(
-            "start" => (new DateTimeImmutable($start))->diff($today),
-            "end" => (new DateTimeImmutable($end))->diff($today)
+            "start" => $today->diff(new DateTimeImmutable($start)),
+            "end" => $today->diff(new DateTimeImmutable($end))
         );
     }
 
@@ -531,12 +535,6 @@ class stundenplandata {
     public static function getTimesForWeekday($day_of_week) {
         $settings = DB::getSettings();
         $periodsCount = $settings->getValue("stundenplan-anzahlstunden");
-
-        if ($settings->getValue("stundenplan-everydayothertimes") <= 0) {
-            // If the timetable uses the same times every day, just query the times for Monday.
-            $day_of_week = 1;
-        }
-
         $times_weekday = array();
         for ($period = 1; $period < $periodsCount; $period++) {
             $times_weekday[$period] = static::getTimesForWeekdayAndPeriod($day_of_week, $period);

--- a/Upload/framework/lib/data/stundenplandata.class.php
+++ b/Upload/framework/lib/data/stundenplandata.class.php
@@ -462,6 +462,102 @@ class stundenplandata {
 		return DB::getSettings()->getValue("stundenplan-anzahlstunden");
 	}
 	
+    /**
+     * @param int $day_of_week The number of the weekday to query (1: Monday, 5: Friday)
+     * @param int[] $periods The numbers of the periods to query (1: first period)
+     * @param bool $continuous Whether periods that directly follow a previous period should be merged (true: do merge)
+     * @return array<array{start: DateInterval, end: DateInterval}>|null
+     */
+    public static function getTimesForWeekdayAndPeriods($day_of_week, $periods, $continuous=false) {
+        if (empty($periods)) { return null; }
+
+        // Ensure that $periods is sorted in an ascending order.
+        // Since the array isn't passed by reference, we don't need to create a copy first.
+        sort($periods, SORT_NUMERIC);
+
+        $times = array();
+        $lastPeriod = null;
+        foreach ($periods as $period) {
+            if (!$continuous) {
+                $times[] = static::getTimesForWeekdayAndPeriod($day_of_week, $period);
+            } elseif ($lastPeriod === null) {
+                $times[] = array("start" => static::getTimesForWeekdayAndPeriod($day_of_week, $period)["start"]);
+            } elseif ($period != $lastPeriod + 1) {
+                end($times)["end"] = stundenplandata::getTimesForWeekdayAndPeriod($day_of_week, $lastPeriod)["end"];
+                $times[] = array("start" => stundenplandata::getTimesForWeekdayAndPeriod($day_of_week, $period)["start"]);
+            }
+            $lastPeriod = $period;
+        }
+
+        if ($continuous && $lastPeriod !== null) {
+            end($times)["end"] = stundenplandata::getTimesForWeekdayAndPeriod($day_of_week, $lastPeriod)["end"];
+        }
+
+        return $times;
+    }
+
+    /**
+     * Returns the start and end time of a specific period on the specified day of week.
+     *
+     * The array contains two array keys, "start" and "end", which map to the start and end times of the queried period, respectively.
+     *
+     * Returns null if no data is available for the specified combination of weekday and period.
+     *
+     * @param int $day_of_week The number of the weekday to query (1: Monday, 5: Friday)
+     * @param int $period The number of the period to query (1: first period)
+     * @return array{start: DateInterval, end: DateInterval}|null
+     */
+    public static function getTimesForWeekdayAndPeriod($day_of_week, $period) {
+        $settings = DB::getSettings();
+        $start = $settings->getValue("stundenplan-stunde-$day_of_week-$period-start");
+        $end = $settings->getValue("stundenplan-stunde-$day_of_week-$period-ende");
+        if ($start === null || $end === null) { return null; }
+
+        $today = new DateTimeImmutable("today");  # This is the current date time at 00:00h.
+        return array(
+            "start" => (new DateTimeImmutable($start))->diff($today),
+            "end" => (new DateTimeImmutable($end))->diff($today)
+        );
+    }
+
+    /**
+     * Returns the start and end times of all periods on the specified day of week.
+     *
+     * The top-level array maps the number of the period (1: first period) to another array containing the start and end times of that period.
+     *
+     * @param int $day_of_week The number of the week day to query (1: Monday, 5: Friday)
+     * @return array<array{start: DateInterval, end: DateInterval}|null>
+     */
+    public static function getTimesForWeekday($day_of_week) {
+        $settings = DB::getSettings();
+        $periodsCount = $settings->getValue("stundenplan-anzahlstunden");
+
+        if ($settings->getValue("stundenplan-everydayothertimes") <= 0) {
+            // If the timetable uses the same times every day, just query the times for Monday.
+            $day_of_week = 1;
+        }
+
+        $times_weekday = array();
+        for ($period = 1; $period < $periodsCount; $period++) {
+            $times_weekday[$period] = static::getTimesForWeekdayAndPeriod($day_of_week, $period);
+        }
+        return $times_weekday;
+    }
+
+    /**
+     * Returns the start and end times of all periods on the timetable.
+     *
+     * The top-level array maps the number of the week day (1: Monday, 5: Friday) to another array, which maps the number of the period (1: first period) to a third array containing the start and end times of that period.
+     *
+     * @return array<array<array{start: DateInterval, end: DateInterval}|null>>
+     */
+    public static function getTimes() {
+        $times = array();
+        for ($day_of_week = 1; $day_of_week < 6; $day_of_week++) {
+            $times[$day_of_week] = static::getTimesForWeekday($day_of_week);
+        }
+        return $times;
+    }
 }
 
 

--- a/Upload/framework/lib/data/stundenplandata.class.php
+++ b/Upload/framework/lib/data/stundenplandata.class.php
@@ -483,14 +483,14 @@ class stundenplandata {
             } elseif ($lastPeriod === null) {
                 $times[] = array("start" => static::getTimesForWeekdayAndPeriod($day_of_week, $period)["start"]);
             } elseif ($period != $lastPeriod + 1) {
-                end($times)["end"] = stundenplandata::getTimesForWeekdayAndPeriod($day_of_week, $lastPeriod)["end"];
+                $times[count($times) - 1]["end"] = stundenplandata::getTimesForWeekdayAndPeriod($day_of_week, $lastPeriod)["end"];
                 $times[] = array("start" => stundenplandata::getTimesForWeekdayAndPeriod($day_of_week, $period)["start"]);
             }
             $lastPeriod = $period;
         }
 
         if ($continuous && $lastPeriod !== null) {
-            end($times)["end"] = stundenplandata::getTimesForWeekdayAndPeriod($day_of_week, $lastPeriod)["end"];
+            $times[count($times) - 1]["end"] = stundenplandata::getTimesForWeekdayAndPeriod($day_of_week, $lastPeriod)["end"];
         }
 
         return $times;

--- a/Upload/framework/lib/data/termine/AbstractTermin.class.php
+++ b/Upload/framework/lib/data/termine/AbstractTermin.class.php
@@ -95,6 +95,57 @@ abstract class AbstractTermin {
 	public function getColor() {
 	    return null;
     }
-	
-}
 
+    /**
+     * Transforms the event to an Event object from Eluceo iCal.
+     *
+     * Returns `false` if no title has been set, or the start or end date could not be parsed using the format `YYYY-MM-DD`.
+     *
+     * @return \Eluceo\iCal\Domain\Entity\Event|false
+     */
+    public function transform() {
+        $title = $this->getTitleRaw();
+        if (empty($title)) { return false; }  // fast skip if title is not set
+
+        $startDate = $this->getDatumStart();
+        $endDate = $this->getDatumEnde();
+
+        $start = \DateTime::createFromFormat('Y-m-d', $startDate);
+        if ($start === false) { return false; }  // skip on malformed dates
+
+        $end = \DateTime::createFromFormat('Y-m-d', $endDate);
+        if ($end === false) { return false; }  // ditto
+
+        if (!$this->isWholeDay()) {
+            $startTime = $this->getUhrzeitStart();
+            $endTime = $this->getUhrzeitEnde();
+            if ($startTime === null && $endTime === null) {  // if both times are missing, assume it's an all-day event even if the marker is missing
+                $allDay = true;
+            } else {
+                // if only one of the two times is present, assume it's an event with no duration
+                // i.e. start time == end time
+                $startTime = $startTime === null ? $endTime : $startTime;
+                $endTime = $endTime === null ? $startTime : $endTime;
+
+                list($startHour, $startMinute) = explode(':', $startTime);
+                list($endHour, $endMinute) = explode(':', $endTime);
+
+                $start->setTime($startHour, $startMinute);
+                $end->setTime($endHour, $endMinute);
+                $allDay = false;
+            }
+        } else {
+            $allDay = true;
+        }
+
+        return ICSFeed::getICSFeedObject(
+            $this->getID(),
+            $title,
+            $start,
+            $end,
+            $this->getOrt(),
+            $this->getKommentar() . ' (Eingetragen von ' . $this->getCreatorName() . ')',
+            $allDay
+        );
+    }
+}

--- a/Upload/framework/lib/data/termine/NamedCalendar.class.php
+++ b/Upload/framework/lib/data/termine/NamedCalendar.class.php
@@ -1,0 +1,18 @@
+<?php
+class NamedCalendar extends \Eluceo\iCal\Domain\Entity\Calendar {
+    private ?string $name = null;
+
+    /**
+     * @param string|null $name
+     * @return NamedCalendar
+     */
+    public function setName($name) {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getName() {
+        return $this->name;
+    }
+}

--- a/Upload/framework/lib/data/termine/NamedCalendarFactory.class.php
+++ b/Upload/framework/lib/data/termine/NamedCalendarFactory.class.php
@@ -1,0 +1,22 @@
+<?php
+use \Eluceo\iCal\Presentation\Component\Property;
+use \Eluceo\iCal\Presentation\Component\Property\Value\TextValue;
+
+/**
+ * Custom CalendarFactory to support the iCalendar NAME and X-WR-CALNAME properties
+ */
+class NamedCalendarFactory extends \Eluceo\iCal\Presentation\Factory\CalendarFactory {
+    protected function getProperties(\Eluceo\iCal\Domain\Entity\Calendar $calendar): Generator {
+        yield from parent::getProperties($calendar);
+
+        if ($calendar instanceof NamedCalendar) {
+            $name = $calendar->getName();
+            if ($name) {
+                // One property for the de-facto standard (RFC 7968)...
+                yield new Property("NAME", new TextValue($name));
+                // ...and one for support (see https://learn.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-oxcical/1da58449-b97e-46bd-b018-a1ce576f3e6d)
+                yield new Property("X-WR-CALNAME", new TextValue($name));
+            }
+        }
+    }
+}

--- a/Upload/framework/lib/page/kalender/geticsfeed.class.php
+++ b/Upload/framework/lib/page/kalender/geticsfeed.class.php
@@ -351,20 +351,18 @@ class geticsfeed extends AbstractPage {
 
         if($withEx) $name .= " (Mit unangekündigten Leisungsnachweisen.)";
 
-        $feedText = "";
-
-        $vCalendar = new \Eluceo\iCal\Component\Calendar(DB::getGlobalSettings()->siteNamePlain);
-        $vCalendar->setPublishedTTL('P1H');
+        $vCalendar = new NamedCalendar();
         $vCalendar->setName($name);
+        $vCalendar->setPublishedTTL(new DateInterval('PT1H')); // recommend a one-hour delay before refreshing the calendar
 
 
         for($i = 0; $i < sizeof($lnwData); $i++) {
             if($lnwData[$i]->showForNotTeacher() || $withEx) {
-                $vCalendar->addComponent(ICSFeed::getICSFeedObject(
+                $vCalendar->addEvent(ICSFeed::getICSFeedObject(
                     "LNW" . $lnwData[$i]->getID(),
                     (($showGrade) ? ($lnwData[$i]->getKlasse() . ": ") : "") . $lnwData[$i]->getArtLangtext() . " in " . $lnwData[$i]->getFach() . " bei " . $lnwData[$i]->getLehrer(),
-                    new DateTime($lnwData[$i]->getDatumStart()),
-                    new DateTime($lnwData[$i]->getDatumStart()),
+                    new \DateTime($lnwData[$i]->getDatumStart()),
+                    new \DateTime($lnwData[$i]->getDatumStart()),
                     $lnwData[$i]->getBetrifft(),
                     "", true));
             }
@@ -372,11 +370,11 @@ class geticsfeed extends AbstractPage {
 
 
         for($i = 0; $i < sizeof($termine); $i++) {
-            $vCalendar->addComponent(ICSFeed::getICSFeedObject(
+            $vCalendar->addEvent(ICSFeed::getICSFeedObject(
                 "KT" . $termine[$i]->getID(),
                 $termine[$i]->getTitle(),
-                new DateTime($termine[$i]->getDatumStart()),
-                new DateTime(($termine[$i]->getDatumStart() != $termine[$i]->getDatumEnde()) ? $termine[$i]->getDatumEnde() : $termine[$i]->getDatumStart()),
+                new \DateTime($termine[$i]->getDatumStart()),
+                new \DateTime(($termine[$i]->getDatumStart() != $termine[$i]->getDatumEnde()) ? $termine[$i]->getDatumEnde() : $termine[$i]->getDatumStart()),
                 $termine[$i]->getOrt(),
                 implode(", ", $termine[$i]->getKlassen()) . "\r\n" . $termine[$i]->getBetrifft(),
                 (($termine[$i]->getDatumStart() != $termine[$i]->getDatumEnde()) ? true : false)));

--- a/Upload/framework/lib/system/schuleinternautoloader.php
+++ b/Upload/framework/lib/system/schuleinternautoloader.php
@@ -113,7 +113,9 @@ $classes = [
 	    'TerminCollector',
 	    'ICSFeed',
         'AbstractKalenderKategorie',
-        'ExternerKalenderKategorie'
+        'ExternerKalenderKategorie',
+        'NamedCalendar',
+        'NamedCalendarFactory'
 	],
     'data/lerntutoren' => [
         'Lerntutor',


### PR DESCRIPTION
Die Änderungen in diesem Pull Request lassen sich auf folgende Punkte zusammenfassen:

1. Die Funktionen `sendAndererKalender`, `sendExternerKalender` und `sendKlassenkalender` wurden überarbeitet um mit der (neuen?) Version von Eluceo iCal kompatibel zu sein. Damit sollte #281 behoben werden. Erste Tests des Klassenkalenders sind vielversprechend;
> [!IMPORTANT]
> **Die anderen zwei Arten von Kalender** (also die, die `sendAndererKalender` und `sendExternerKalender` verwenden) **habe ich leider nicht testen können.** Das sollte also unbedingt noch gemacht werden!
2. Um mit der neuen Eluceo iCal-Version dem Kalender einen Namen zu verleihen, wurden außerdem noch zwei weitere Klassen hinzugefügt (`NamedCalendar` und `NamedCalendarFactory`) und im Autoloader ergänzt. Zwar habe ich bis jetzt noch nicht feststellen können, dass der Name auch wirklich von einem Kalenderprogramm verwendet wird (getestet: Thunderbird 115); Den Quellcode kann man aber im Nachhinein einfach anpassen.
3. Im Zuge der notwendigen Änderungen wurde in `sendKlassenkalender` auch die Unterstützung für die Konvertierung von Unterrichtsstunden zu Uhrzeiten hinzugefügt. Das würde [das Foren-Thema "Kalender: Uhrzeiten im Klassenkalender-ICS-Feed"](https://forum.schule-intern.de/forum/index.php?thread/354-kalender-uhrzeiten-im-klassenkalender-ics-feed/&postID=2119#post2119) erledigen.
4. Für die Umwandlung von Stunden zu Uhrzeiten gibt es eine Handvoll neuer Hilfsfunktionen in `stundenplandata`, welche die benötigten Daten über die Einstellungen `stundenplan-stunde-<wochentag>-<stunde>-start` bzw. `stundenplan-stunde-<wochentag>-<stunde>-ende` und `stundenplan-everydayothertimes` beziehen. Die hinzugefügten Kommentare sollten das Verhalten der Funktionen ausreichend beschreiben (bitte melden, falls nicht!).

----

Wie bereits erwähnt, stehe ich bei Feedback oder Rückfragen gerne per E-Mail oder Foren-Nachricht zur Verfügung.